### PR TITLE
feat: Implement standard profile and enhance metadata

### DIFF
--- a/src/py_load_uniprot/cli.py
+++ b/src/py_load_uniprot/cli.py
@@ -1,5 +1,6 @@
 import typer
 from rich import print
+from rich.markup import escape
 from pathlib import Path
 from typing_extensions import Annotated
 import json
@@ -38,10 +39,10 @@ def main_callback(
     try:
         initialize_settings(config_file=config)
     except FileNotFoundError as e:
-        print(f"[bold red]Configuration Error: {e}[/bold red]")
+        print(f"[bold red]Configuration Error: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
     except Exception as e:
-        print(f"[bold red]An unexpected error occurred during initialization: {e}[/bold red]")
+        print(f"[bold red]An unexpected error occurred during initialization: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
 
 
@@ -89,7 +90,7 @@ def download(
                     print(f"[bold red]Checksum verification failed for '{ds}'.[/bold red]")
                     failed_downloads.append(ds)
             except Exception as e:
-                print(f"[bold red]An error occurred while downloading {ds}: {e}[/bold red]")
+                print(f"[bold red]An error occurred while downloading {ds}: {escape(str(e))}[/bold red]")
                 failed_downloads.append(ds)
 
         if failed_downloads:
@@ -99,10 +100,10 @@ def download(
             print("\n[bold green]All specified datasets downloaded successfully.[/bold green]")
 
     except FileNotFoundError as e:
-        print(f"\n[bold red]Configuration Error: {e}[/bold red]")
+        print(f"\n[bold red]Configuration Error: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
     except Exception as e:
-        print(f"\n[bold red]An unexpected error occurred during the download process: {e}[/bold red]")
+        print(f"\n[bold red]An unexpected error occurred during the download process: {escape(str(e))}[/bold red]")
         import traceback
         traceback.print_exc()
         raise typer.Exit(code=1)
@@ -119,10 +120,10 @@ def run(
         pipeline = PyLoadUniprotPipeline()
         pipeline.run(dataset=dataset, mode=mode)
     except (ValueError, FileNotFoundError) as e:
-        print(f"\n[bold red]Configuration Error: {e}[/bold red]")
+        print(f"\n[bold red]Configuration Error: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
     except Exception as e:
-        print(f"\n[bold red]An unexpected error occurred during the ETL pipeline: {e}[/bold red]")
+        print(f"\n[bold red]An unexpected error occurred during the ETL pipeline: {escape(str(e))}[/bold red]")
         import traceback
         traceback.print_exc()
         raise typer.Exit(code=1)
@@ -157,7 +158,7 @@ def check_config():
         print("\n[bold green]Configuration and connectivity check passed.[/bold green]")
 
     except Exception as e:
-        print(f"\n[bold red]An error occurred during the check: {e}[/bold red]")
+        print(f"\n[bold red]An error occurred during the check: {escape(str(e))}[/bold red]")
         import traceback
         traceback.print_exc()
         raise typer.Exit(code=1)
@@ -176,7 +177,7 @@ def initialize():
         print("\n[bold green]CLI command 'initialize' completed successfully.[/bold green]")
         print(f"Production schema '{db_adapter.production_schema}' is ready.")
     except Exception as e:
-        print(f"\n[bold red]An error occurred during schema initialization: {e}[/bold red]")
+        print(f"\n[bold red]An error occurred during schema initialization: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
 
 
@@ -194,7 +195,7 @@ def status():
         else:
             print("  [yellow]No UniProt release is currently loaded in the database.[/yellow]")
     except Exception as e:
-        print(f"\n[bold red]An error occurred while checking the status: {e}[/bold red]")
+        print(f"\n[bold red]An error occurred while checking the status: {escape(str(e))}[/bold red]")
         raise typer.Exit(code=1)
 
 def main():

--- a/src/py_load_uniprot/config.py
+++ b/src/py_load_uniprot/config.py
@@ -15,7 +15,7 @@ Nested keys are separated by double underscores, e.g., PY_LOAD_UNIPROT_DB__HOST.
 """
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -30,6 +30,11 @@ class DBSettings(BaseModel):
     user: str = "postgres"
     password: str = "password"
     dbname: str = "uniprot"
+
+    @property
+    def connection_string(self) -> str:
+        """Generates a psycopg2-compatible connection string."""
+        return f"dbname='{self.dbname}' user='{self.user}' host='{self.host}' port='{self.port}' password='{self.password}'"
 
 
 class URLSettings(BaseModel):
@@ -56,6 +61,10 @@ class Settings(BaseSettings):
     """
     Main configuration class for the application.
     """
+    profile: Literal["full", "standard"] = Field(
+        default="full",
+        description="The data extraction profile to use ('full' or 'standard')."
+    )
     data_dir: Path = Field(default="data", description="Directory to store downloaded UniProt files.")
     db: DBSettings = Field(default_factory=DBSettings)
     urls: URLSettings = Field(default_factory=URLSettings)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -175,5 +175,5 @@ def test_get_release_info_parse_error(mock_get: MagicMock, extractor: Extractor)
     mock_get.return_value = mock_response
 
     # --- Act & Assert ---
-    with pytest.raises(ValueError, match="Could not parse release information"):
+    with pytest.raises(ValueError, match="Could not parse release version/date from reldate.txt"):
         extractor.get_release_info()

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -68,7 +68,7 @@ def test_transform_xml_to_tsv_creates_correct_output(sample_xml_file: Path, tmp_
     output_dir = tmp_path / "output"
 
     # Act
-    transformer.transform_xml_to_tsv(sample_xml_file, output_dir)
+    transformer.transform_xml_to_tsv(sample_xml_file, output_dir, profile="full")
 
     # Assert all expected files are created
     for table_name in transformer.TABLE_HEADERS.keys():
@@ -165,7 +165,7 @@ def test_parse_entry_extracts_evidence_data():
     elem = etree.fromstring(xml_string)
 
     # Act
-    parsed_data = transformer._parse_entry(elem)
+    parsed_data = transformer._parse_entry(elem, profile="full")
 
     # Assert
     assert "proteins" in parsed_data
@@ -195,7 +195,7 @@ def test_parse_entry_extracts_evidence_data():
 
 # --- Test for parallel implementation ---
 
-def transform_xml_to_tsv_single_threaded(xml_file: Path, output_dir: Path):
+def transform_xml_to_tsv_single_threaded(xml_file: Path, output_dir: Path, profile: str):
     """
     A single-threaded version of the transformer, kept for baseline comparison.
     """
@@ -207,7 +207,7 @@ def transform_xml_to_tsv_single_threaded(xml_file: Path, output_dir: Path):
         seen_taxonomy_ids = set()
 
         for _, elem in context:
-            parsed_data = transformer._parse_entry(elem)
+            parsed_data = transformer._parse_entry(elem, profile)
 
             for table_name, rows in parsed_data.items():
                 if table_name == "taxonomy":
@@ -239,9 +239,9 @@ def test_parallel_transformer_matches_single_threaded(sample_xml_file: Path, tmp
 
     # Act
     # Run single-threaded version
-    transform_xml_to_tsv_single_threaded(sample_xml_file, output_single)
+    transform_xml_to_tsv_single_threaded(sample_xml_file, output_single, profile="full")
     # Run parallel version
-    transformer.transform_xml_to_tsv(sample_xml_file, output_parallel, num_workers=2)
+    transformer.transform_xml_to_tsv(sample_xml_file, output_parallel, profile="full", num_workers=2)
 
     # Assert
     # Check that the same files were created


### PR DESCRIPTION
This commit introduces two main features from the FRD and fixes several bugs.

Features:
- Adds a 'standard' data extraction profile that can be set in the configuration. This profile provides a lighter-weight extraction by omitting large and complex JSONB fields (features, db_references, evidence), improving performance and reducing storage requirements for users who only need core data.
- Enhances metadata extraction to parse Swiss-Prot and TrEMBL entry counts from the `relnotes.txt` file, in addition to the version and date from `reldate.txt`. This information is now correctly stored in the metadata table.

Bug Fixes:
- Corrected a critical bug in the 'full load' schema swap logic where the metadata and history tables were being dropped and recreated, causing loss of data. These tables are now managed persistently in the production schema.
- Fixed an issue where the application would crash with a `rich.errors.MarkupError` if an exception message contained characters that Rich interprets as markup. All user-facing exception prints are now correctly escaped.
- Fixed a bug where the pipeline was attempting to call a non-existent `run_extraction` function.
- Corrected various issues in the integration tests to ensure they run correctly and accurately reflect the application's behavior.